### PR TITLE
Fixed an issue with the regex for multi line comments.

### DIFF
--- a/Contents/Resources/SyntaxDefinition.xml
+++ b/Contents/Resources/SyntaxDefinition.xml
@@ -4,30 +4,30 @@
 
     <head>
         <name>CoffeeScript</name>
-        <charsintokens><![CDATA[@$_0987654321abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]]></charsintokens> 
+        <charsintokens><![CDATA[@$_0987654321abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]]></charsintokens>
     </head>
 
     <states>
 
         <default id="Base" color="#363636" inverted-color="#f0f" scope="meta.default">
-            
+
             <!--
             WIP - Folding support
-            
+
             <state id="Block" foldable="yes">
-      				<begin><regex>^(?'indent'\s*)\S</regex></begin>
-      				<end><regex>\n(?=(?#see-insert-start-group:indent)\S)</regex></end>
-      				<import />
-      			</state>
-      			-->
-            
+                      <begin><regex>^(?'indent'\s*)\S</regex></begin>
+                      <end><regex>\n(?=(?#see-insert-start-group:indent)\S)</regex></end>
+                      <import />
+                  </state>
+                  -->
+
             <state id="Function" scope="language.function">
               <begin><regex>(?:\([^()]*\)\s*)?[-=](?=>)</regex></begin>
               <end><regex>></regex></end>
             </state>
 
             <state id="Comment" scope="comment">
-                <begin><string>#{3}\s*\n</string></begin>
+                <begin><string>#{3}[^#]</string></begin>
                 <end><string>###</string></end>
             </state>
 
@@ -45,14 +45,14 @@
                   <end><string>}</string></end>
                   <import />
                 </state>
-                
+
             </state>
-            
+
             <state id="Single String 3" scope="string">
                 <begin><string>'''</string></begin>
                 <end><regex>((\\\\)*(?&lt;!\\))'''</regex></end>
             </state>
-            
+
             <state id="String" scope="string">
                 <begin><string>"</string></begin>
                 <end><regex>((\\\\)*(?&lt;!\\))"</regex></end>
@@ -62,14 +62,14 @@
                   <end><string>}</string></end>
                   <import mode="CoffeeScript" />
                 </state>
-                
+
             </state>
 
             <state id="Single String" scope="string">
                 <begin><string>'</string></begin>
                 <end><regex>((\\\\)*(?&lt;!\\))'</regex></end>
             </state>
-            
+
             <state id="RegularExpression" scope="string.regex">
                 <!-- copied from CODA2 Javascript.mode -->
                 <begin><regex>(?i)(?&lt;=[=(,:\+~!]|return|;)\s*/(?![/*+{}?\r\n])</regex></begin>
@@ -77,16 +77,16 @@
 
                 <state id="Escaped Characters" scope="string.regex.escaped.js">
                     <begin><regex>\\</regex></begin>
-                    <end><regex>.</regex></end>	
+                    <end><regex>.</regex></end>
                 </state>
             </state>
-            
+
             <state id="Embedded JavaScript" scope="string">
               <begin><string>`</string></begin>
               <end><string>`</string></end>
               <import mode="JavaScript" />
             </state>
-            
+
             <keywords id="Keywords" useforautocomplete="yes" scope="keyword.control">
                 <string>if</string>
                 <string>unless</string>
@@ -119,19 +119,19 @@
                 <string>instanceof</string>
                 <string>typeof</string>
             </keywords>
-            
+
             <keywords id="Operators" scope="language.operator">
               <regex>([-+*/=!&lt;>%])</regex>
             </keywords>
-            
+
             <keywords id="Object Keys" scope="language.variable">
               <regex>\s*([\w$]+)\s*[^\w$.]</regex>
             </keywords>
-            
+
             <keywords id="Numbers" scope="constant.numeric">
               <regex>(?&lt;=[^\w\d]|^)(((([0-9]+\.[0-9]*)|(\.[0-9]+))([eE][+\-]?[0-9]+)?[fFlL]?)|((([1-9][0-9]*)|0[0-7]*|(0[xX][0-9a-fA-F]+))(([uU][lL]?)|([lL][uU]?))?))(?=[^\w\$]|$)</regex>
             </keywords>
-            
+
             <keywords id="Number Literals" useforautocomplete="yes" scope="constant.numeric.keyword">
                 <string>true</string>
                 <string>yes</string>
@@ -144,7 +144,7 @@
                 <string>infinity</string>
                 <string>undefined</string>
             </keywords>
-            
+
             <keywords id="Properties" scope="keyword.type">
               <regex>(@\w*)</regex>
               <regex>(@?[$\w]+\s*:)</regex>
@@ -153,7 +153,7 @@
             <keywords id="Classes" scope="support">
               <regex>(\b[A-Z]\w*)</regex>
             </keywords>
-            
+
         </default>
 
     </states>


### PR DESCRIPTION
Issue Example:

```
#### Comment here
```

This would cause an open multiline comment when it should actually be read as a single line comment. My Fix takes care of these situations.
